### PR TITLE
Issue 3 - Added functionality to save generated images during evaluation

### DIFF
--- a/GAN/GAN_scratch/models/GAN.py
+++ b/GAN/GAN_scratch/models/GAN.py
@@ -7,6 +7,7 @@ import torchvision.transforms as transforms
 import torchvision.utils as vutils
 from torchvision import datasets, transforms
 import torch.nn.utils.spectral_norm as spectral_norm
+import os
 
 # Self-Attention Module Placeholder
 class SelfAttention(nn.Module):
@@ -144,11 +145,21 @@ class CIFAR10Dataset(Dataset):
         return image, label
 
 # Evaluate Function Placeholder
-def evaluate(generator, latent_dim, device):
+def evaluate(generator, latent_dim, device, output_dir="generated_images", n_images=16):
     generator.eval()
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
     with torch.no_grad():
-        z = torch.randn(16, latent_dim, device=device)
+        z = torch.randn(n_images, latent_dim, device=device)
+        
         gen_imgs = generator(z)
+
+        save_path = os.path.join(output_dir, "generated_grid.png")
+        vutils.save_image(gen_imgs, save_path, normalize=True, nrow=4)
+
+    print(f"Generated images saved to {save_path}")
     generator.train()
 
 # GAN Training Loop


### PR DESCRIPTION
Added functionality to save generated images during evaluation

- Updated the evaluate function to generate and save a grid of images using torchvision.utils.save_image.
  - The generator now produces a batch of n_images (default: 16) during evaluation, which is saved as a grid.
  - Images are normalized before saving to ensure proper display in the grid format.
  
- Created an output directory (default: 'generated_images') if it does not exist to store the generated images.
  - The generated image grid is saved as 'generated_grid.png' in the specified directory.
  
- This allows visual tracking of the GAN's performance by saving sample images at evaluation time.
  